### PR TITLE
Fix link to Mac OS X wallet download

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,7 @@
                             </div>
                             <div class="col-md-6 col-sm-7 col-sm-offset-1">
                                 <br>
-                                <a href="https://github.com/PaycoinFoundation/paycoin/releases/download/v0.3.1.1/mac.zip">OS X Wallet</a>
+                                <a href="https://github.com/PaycoinFoundation/paycoin/releases/download/v0.3.1.0/mac.zip">OS X Wallet</a>
                             </div>
                         </div>
                         <hr class="hr2">


### PR DESCRIPTION
There is no v0.3.1.1 release for Mac as of yet.
