### PR TITLE
Replace Brand Resources/Additional Information with Network Burn Address

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,23 +356,16 @@
 
             <!-- Brand column -->
             <div class="col-md-4, col-sm-4">
-                <h4>Brand Resources</h4>
-                <p>Paycoin logo and branding information check out the Merchant section for some useful downloads.
-
-
+                <h4>Network Burn Address</h4>
+                <p>
+                  A burn address is a proveably unspendable address that removes any Paycoin sent to it from the total money supply.
+                  <br>
+                  <br>
+                  The burn address for the Paycoin network is:
+                  <br>
+                  <b><a href="https://ledger.paycoin.com/address/PLgqKBNdyGJ4rC21efAQhDUsrZZRU4qcQo" target="_blank">PLgqKBNdyGJ4rC21efAQhDUsrZZRU4qcQo</a></b>
                 </p>
 
-
-                <p class="no-padding-margin">Additional Information:</p><p> what is Paycoin?<br>(basic guide)
-            </p>
-                <div class="row">
-                    <div class="col-mid-6 col-sm-6">
-                        <a href="/downloads/paycoindoc.pdf" target="_blank" class="pdf-btn">
-                            <img src="/img/pdf.png" alt="Paycoin additional information">
-                        </a> Paycoin
-                    </div>
-
-                </div>
             </div>
             <!-- end onepay column -->
             <div class="col-md-1, col-sm-1"></div>


### PR DESCRIPTION
- Remove the Brand Resources section as it was just pointing the user to the information above it in the Merchant Resources section.
- I have also removed the Additional Information PDF as I hate linking to a PDF and I don’t think it was overly useful plus had a lot of outdated information.
- Add a new section with information regarding the Network Burn Address
